### PR TITLE
fix rename bug

### DIFF
--- a/fzt_explorer.zsh
+++ b/fzt_explorer.zsh
@@ -193,7 +193,7 @@ function _fzt_explorer_func_rename() {
   if [ -n "$_fzt_explorer_var_check_not_include_slash" ]; then
     echo "Including '/' is not valid."
   else;
-    mv "$PWD/$_fzt_explorer_var_selected_path" "$PWD/$_fzt_explorer_var_newname"
+    mv -iT "$PWD/$_fzt_explorer_var_selected_path" "$PWD/$_fzt_explorer_var_newname"
   fi
 }
 


### PR DESCRIPTION
resolve #16 
リネーム時に名前がかぶっていた場合これまでは確認無しで上書きされていた

# 変更点
オプション-iTを付けた
- 上書き確認をするように
- 変更先がディレクトリ名と同じだった場合，ディレクトリではなくファイル名として扱う（これまではディレクトリに移動していたが，移動せずにリネームする）